### PR TITLE
Remove the host header before forwarding

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -43,6 +43,9 @@ class Client {
 
     delete data.query
 
+    // Remove the host header, leaving it causes issues with SNI and TLS verification
+    delete data.host
+
     const req = superagent.post(url.format(target)).send(data.body)
 
     delete data.body


### PR DESCRIPTION
With some hosts behind shared TLS (using SNI), keeping the Host header was causing the target host to be misidentified.

I also observed issues related to TLS verification (as seen in #156).

Fixes #156