### PR TITLE
Bump to `1.2.4`; fix code coverage report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
-name: Test
-"on":
+name: CI
+on:
   push:
     branches:
       - main
@@ -8,7 +8,7 @@ name: Test
       - opened
       - synchronize
 jobs:
-  test_matrix:
+  test:
     strategy:
       matrix:
         node-version:
@@ -22,36 +22,26 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           cache: npm
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies
         run: npm ci
-      - name: Build
-        run: npm run build
-      - name: Run tests
-        run: npx jest
-  test:
-    runs-on: ubuntu-latest
-    needs: test_matrix
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Set up Node.js 18
-        uses: actions/setup-node@v3
-        with:
-          cache: npm
-          node-version: 18
-      - name: Install dependencies
-        run: npm ci
       - name: Linting
         run: npm run lint
-      - name: Build
-        run: npm run build
       - name: Run tests and collect coverage
+        if: matrix.os == 'ubuntu-latest' && matrix.node-version == 18
         run: npm run test
+      - name: Run tests without coverage
+        if: matrix.os != 'ubuntu-latest' || matrix.node-version != 18
+        run: npx jest
+      - name: Build
+        # Build must follow testing so coverage won't be message up by the
+        # generated .js files.
+        run: npm run build
       - name: Upload coverage to https://codecov.io
+        if: matrix.os == 'ubuntu-latest' && matrix.node-version == 18
         uses: codecov/codecov-action@v3

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "smee-client",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "smee-client",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "license": "ISC",
       "dependencies": {
         "commander": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smee-client",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Client to proxy webhooks to local host",
   "main": "index.js",
   "bin": {
@@ -9,15 +9,14 @@
   "files": [
     "index.js",
     "index.d.ts",
-    "bin",
-    "lib"
+    "bin"
   ],
   "scripts": {
-    "test": "npx jest --coverage && standard",
-    "lint": "npx eslint index.ts bin/smee.js test/index.test.ts",
+    "test": "jest --coverage && standard",
+    "lint": "eslint index.ts bin/smee.js test/index.test.ts",
     "build": "tsc -p tsconfig.json"
   },
-  "repository": "github:probot/smee-client",
+  "repository": "github:distributed-system-analysis/smee-client",
   "author": "",
   "license": "ISC",
   "dependencies": {
@@ -56,6 +55,11 @@
     ]
   },
   "jest": {
-    "preset": "ts-jest"
+    "clearMocks": true,
+    "collectCoverage": false,
+    "coverageProvider": "v8",
+    "coverageReporters": ["text", "cobertura"],
+    "preset": "ts-jest",
+    "testEnvironment": "node"
   }
 }


### PR DESCRIPTION
Correct CI workflow name and fold coverage into test matrix without repeating a test.